### PR TITLE
Loosen Faraday constraint to allow 0.10

### DIFF
--- a/bitbucket_rest_api.gemspec
+++ b/bitbucket_rest_api.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w[ lib ]
 
   gem.add_dependency 'hashie'
-  gem.add_dependency 'faraday', '~> 0.9.0'
+  gem.add_dependency 'faraday', '~> 0.9'
   gem.add_dependency 'multi_json',  '>= 1.7.5', '< 2.0'
-  gem.add_dependency 'faraday_middleware', '~> 0.9.0'
+  gem.add_dependency 'faraday_middleware', '~> 0.9'
   gem.add_dependency 'nokogiri', '>= 1.5.2'
   gem.add_dependency 'simple_oauth'
 


### PR DESCRIPTION
The API's are compliant between 0.9.x and 0.10.x so this loosens that to allow for the more recent versions of Faraday.